### PR TITLE
Navigate to definition in Turtle files

### DIFF
--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,14 +1,14 @@
 import { Definition, DefinitionProvider, Location, LocationLink, Position, ProviderResult, Range, RelativePattern, TextDocument, Uri, workspace } from 'vscode'
 
-type MatchLocation = ProviderResult<Definition | LocationLink[]> | null
+type MatchLocation = ProviderResult<Definition | LocationLink[]> | undefined
 
 export class TurtleDefinitionProvider implements DefinitionProvider {
     provideDefinition(document: TextDocument, position: Position): MatchLocation {
-        const symbol = document.getText(document.getWordRangeAtPosition(position))
-        const regex = definitionRegex(symbol)
+        const word = document.getText(document.getWordRangeAtPosition(position))
+        const identifier = new Identifier(word, getPrefixMapping(document.getText()))
         return findTurtleDocuments().then(documents => {
             for (let doc of documents) {
-                const result = findMatchInDocument(doc, regex)
+                const result = findMatchInDocument(doc, identifier)
                 if (result) {
                     return result
                 }
@@ -18,7 +18,38 @@ export class TurtleDefinitionProvider implements DefinitionProvider {
     }
 }
 
-const definitionRegex = (str: string) => new RegExp(`(?<=\\.\\s*)\\b${str}\\b`, 'g')
+class Identifier {
+    private readonly prefix: string
+    private readonly localName: string
+    
+    constructor(word: string, mapping: Map<string, string>) {
+        const trimmed = word.trim()
+        this.prefix = mapping.get(trimmed.substring(0, trimmed.indexOf(':'))) || ''
+        this.localName = word.substring(trimmed.indexOf(':') + 1, trimmed.length)
+    }
+    
+    getRegexForMapping(mapping: Map<string, string>): RegExp {
+        const entry = Array.from(mapping.entries()).filter(e => e[1] === this.prefix)[0]
+        if (!entry) {
+            return definitionRegex(`<${this.prefix}${this.localName}>`)
+        }
+        return definitionRegex(`(${entry[0]}:${this.localName})|(<${this.prefix}${this.localName}>)`)
+    }
+}
+
+const definitionRegex = (str: string) => new RegExp(`(?<=(\\.|^)\\s*)(${str})`, 'g')
+
+function getPrefixMapping(text: string): Map<string, string> {
+    const resultMap = new Map<string, string>()
+    prefixes(text)?.map(str => str.trim()).forEach(str => {
+        const key = str.substring(0, str.indexOf(':'))
+        const value = str.substring(str.indexOf('<') + 1, str.indexOf('>'))
+        resultMap.set(key, value)
+    })
+    return resultMap
+}
+
+const prefixes = (str: string) => /(?<=@prefix\s*)[a-zA-z0-9_-]*\s*:\s*<.+>(?=\s*\.)/g.exec(str)
 
 async function findTurtleDocuments(): Promise<TextDocument[]> {
     const folders = workspace.workspaceFolders
@@ -37,9 +68,10 @@ async function findTurtleDocuments(): Promise<TextDocument[]> {
     return await Promise.all(documentPromises)
 }
 
-function findMatchInDocument(doc: TextDocument, regex: RegExp): MatchLocation {
+function findMatchInDocument(doc: TextDocument, identifier: Identifier): MatchLocation {
     const text = doc.getText()
     
+    const regex = identifier.getRegexForMapping(getPrefixMapping(text))
     const match = regex.exec(text)
     if (!match) {
         return undefined

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -6,20 +6,37 @@ export class TurtleDefinitionProvider implements DefinitionProvider {
     provideDefinition(document: TextDocument, position: Position): MatchLocation {
         const symbol = document.getText(document.getWordRangeAtPosition(position))
         const regex = definitionRegex(symbol)
-        for (let doc of turtleDocuments()) {
-            const result = findMatchInDocument(doc, regex, symbol)
-            if (result) {
-                return result
+        return findTurtleDocuments().then(documents => {
+            for (let doc of documents) {
+                const result = findMatchInDocument(doc, regex)
+                if (result) {
+                    return result
+                }
             }
-        }
-        return undefined
+            return undefined
+        })
     }
 }
 
 const definitionRegex = (str: string) => new RegExp(`(?<=\\.\\s*)\\b${str}\\b`, 'g')
-const turtleDocuments = () => workspace.textDocuments.filter(d => d.languageId === 'turtle')
 
-function findMatchInDocument(doc: TextDocument, regex: RegExp, symbol: string): MatchLocation {
+async function findTurtleDocuments(): Promise<TextDocument[]> {
+    const folders = workspace.workspaceFolders;
+    if (!folders) {
+        return [];
+    }
+
+    const files: Uri[] = [];
+    for (const folder of folders) {
+        const folderFiles = await workspace.findFiles(new RelativePattern(folder, '**/*.ttl'));
+        files.push(...folderFiles);
+    }
+
+    const documentPromises = files.map(async file => await workspace.openTextDocument(file));
+    return await Promise.all(documentPromises);
+}
+
+function findMatchInDocument(doc: TextDocument, regex: RegExp): MatchLocation {
     const text = doc.getText()
     
     const match = regex.exec(text)
@@ -29,13 +46,14 @@ function findMatchInDocument(doc: TextDocument, regex: RegExp, symbol: string): 
 
     const textBeforeMatch = text.substring(0, match.index)
     const lineNumber = textBeforeMatch.match(/\n/g)?.length || 0
-
+    
+    const symbol = match[0]
     const startIndex = doc.lineAt(lineNumber).text.indexOf(symbol)
     if (startIndex === -1) {
         return undefined
     }
 
     const start = new Position(lineNumber, startIndex)
-    const end = new Position(lineNumber, startIndex + match[0].length)
+    const end = new Position(lineNumber, startIndex + symbol.length)
     return new Location(doc.uri, new Range(start, end))
 }

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -21,19 +21,20 @@ export class TurtleDefinitionProvider implements DefinitionProvider {
 const definitionRegex = (str: string) => new RegExp(`(?<=\\.\\s*)\\b${str}\\b`, 'g')
 
 async function findTurtleDocuments(): Promise<TextDocument[]> {
-    const folders = workspace.workspaceFolders;
+    const folders = workspace.workspaceFolders
     if (!folders) {
-        return [];
+        return []
     }
 
-    const files: Uri[] = [];
+    const files: Uri[] = []
     for (const folder of folders) {
-        const folderFiles = await workspace.findFiles(new RelativePattern(folder, '**/*.ttl'));
-        files.push(...folderFiles);
+        const pattern = new RelativePattern(folder, '**/*.ttl')
+        const folderFiles = await workspace.findFiles(pattern)
+        files.push(...folderFiles)
     }
 
-    const documentPromises = files.map(async file => await workspace.openTextDocument(file));
-    return await Promise.all(documentPromises);
+    const documentPromises = files.map(async file => await workspace.openTextDocument(file))
+    return await Promise.all(documentPromises)
 }
 
 function findMatchInDocument(doc: TextDocument, regex: RegExp): MatchLocation {
@@ -46,7 +47,7 @@ function findMatchInDocument(doc: TextDocument, regex: RegExp): MatchLocation {
 
     const textBeforeMatch = text.substring(0, match.index)
     const lineNumber = textBeforeMatch.match(/\n/g)?.length || 0
-    
+
     const symbol = match[0]
     const startIndex = doc.lineAt(lineNumber).text.indexOf(symbol)
     if (startIndex === -1) {

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,0 +1,41 @@
+import { Definition, DefinitionProvider, Location, LocationLink, Position, ProviderResult, Range, RelativePattern, TextDocument, Uri, workspace } from 'vscode'
+
+type MatchLocation = ProviderResult<Definition | LocationLink[]> | null
+
+export class TurtleDefinitionProvider implements DefinitionProvider {
+    provideDefinition(document: TextDocument, position: Position): MatchLocation {
+        const symbol = document.getText(document.getWordRangeAtPosition(position))
+        const regex = definitionRegex(symbol)
+        for (let doc of turtleDocuments()) {
+            const result = findMatchInDocument(doc, regex, symbol)
+            if (result) {
+                return result
+            }
+        }
+        return undefined
+    }
+}
+
+const definitionRegex = (str: string) => new RegExp(`(?<=\\.\\s*)\\b${str}\\b`, 'g')
+const turtleDocuments = () => workspace.textDocuments.filter(d => d.languageId === 'turtle')
+
+function findMatchInDocument(doc: TextDocument, regex: RegExp, symbol: string): MatchLocation {
+    const text = doc.getText()
+    
+    const match = regex.exec(text)
+    if (!match) {
+        return undefined
+    }
+
+    const textBeforeMatch = text.substring(0, match.index)
+    const lineNumber = textBeforeMatch.match(/\n/g)?.length || 0
+
+    const startIndex = doc.lineAt(lineNumber).text.indexOf(symbol)
+    if (startIndex === -1) {
+        return undefined
+    }
+
+    const start = new Position(lineNumber, startIndex)
+    const end = new Position(lineNumber, startIndex + match[0].length)
+    return new Location(doc.uri, new Range(start, end))
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import {
 import { RDFoxCompletionProvider, FunctionCompletionProvider } from './completion';
 import { RDFoxHoverProvider } from './hover';
 import { CommandMap, FunctionMap } from './types';
+import { TurtleDefinitionProvider } from './definition';
 
 export function activate(context: vscode.ExtensionContext) {
     const commandMap: CommandMap = _commandMap
@@ -29,6 +30,10 @@ export function activate(context: vscode.ExtensionContext) {
     )
     context.subscriptions.push(
         vscode.languages.registerCompletionItemProvider('datalog', new FunctionCompletionProvider(functionMap))
+    )
+
+    context.subscriptions.push(
+        vscode.languages.registerDefinitionProvider('turtle', new TurtleDefinitionProvider())
     )
 
     context.subscriptions.push(


### PR DESCRIPTION
# Why?
I've been missing navigating to the definition of RDF resources in Turtle files.
To address this, I've implemented a feature that allows to easily jump to the definition of a resource within Turtle files present inside the currently open workspace.

# What?
When you Ctrl + Click on a resource or press F12, the extension will navigate you to its definition.
If no definition is found within the open folder, the assumption is made that there is no definition.

# How?
I've implemented this feature by relying regular expressions to handle the heavy lifting.
While I acknowledge that there might be alternative and potentially more efficient approaches to lookup definitions, this method has proven good enough to me.
I hope that this feature proves valuable not only for me but for other users as well.